### PR TITLE
EL2使用時のNoClassDefFoundErrorを修正

### DIFF
--- a/src/main/java/com/gh/mygreen/xlsmapper/expression/AbstractExpressionLanguageELImpl.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/expression/AbstractExpressionLanguageELImpl.java
@@ -1,0 +1,70 @@
+package com.gh.mygreen.xlsmapper.expression;
+
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.validator.internal.engine.messageinterpolation.el.RootResolver;
+
+import com.gh.mygreen.xlsmapper.ArgUtils;
+import com.github.mygreen.expression.el.FormatterWrapper;
+import com.github.mygreen.expression.el.tld.Taglib;
+import com.github.mygreen.expression.el.tld.TldLoader;
+
+
+/**
+ * ExpressionLanguageELImpl*で使用する共通メソッドを定義する抽象クラス。
+ * 
+ * @version 1.5
+ * 
+ */
+public abstract class AbstractExpressionLanguageELImpl {
+    
+    /** TLDファイルの定義内容 */
+    protected List<Taglib> taglibList = new ArrayList<>();
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Object evaluate(final String expression, final Map<String, ?> values) {
+        
+        ArgUtils.notEmpty(expression, "expression");
+        ArgUtils.notEmpty(values, "values");
+        
+        return doEvaluate(expression, values);
+        
+    }
+    
+    protected abstract Object doEvaluate(final String expression, final Map<String, ?> values);
+    
+    /**
+     * {@link FormatterWrapper}で囲むべき値かどうか判定する。
+     * @param key
+     * @param value
+     * @return
+     */
+    protected boolean isFormatter(final String key, final Object value) {
+        if(!RootResolver.FORMATTER.equals(key)) {
+            return false;
+        }
+        
+        if(value instanceof Formatter) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * カスタムタグの定義ファイル「TLD（Tag Library Defenitioin）」を登録する。
+     * <p>{@link TldLoader}クラスで読み込む。
+     * 
+     * @since 1.5
+     * @param taglib カスタムタグの定義内容。
+     */
+    public void register(final Taglib taglib) {
+        this.taglibList.add(taglib);
+    }
+    
+}

--- a/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl.java
@@ -1,24 +1,7 @@
 package com.gh.mygreen.xlsmapper.expression;
 
-import java.util.ArrayList;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
-import javax.el.BeanNameResolver;
-import javax.el.ELException;
-import javax.el.ELProcessor;
-
-import org.hibernate.validator.internal.engine.messageinterpolation.el.RootResolver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.gh.mygreen.xlsmapper.ArgUtils;
-import com.gh.mygreen.xlsmapper.Utils;
-import com.github.mygreen.expression.el.FormatterWrapper;
-import com.github.mygreen.expression.el.tld.Function;
 import com.github.mygreen.expression.el.tld.Taglib;
 import com.github.mygreen.expression.el.tld.TldLoader;
 
@@ -32,21 +15,28 @@ import com.github.mygreen.expression.el.tld.TldLoader;
  */
 public class ExpressionLanguageELImpl implements ExpressionLanguage {
     
-    private static final Logger logger = LoggerFactory.getLogger(ExpressionLanguageELImpl.class);
-    
     /** EL3.xが使用可能かどうか */
-    private boolean availabledEl3;
-    {
+    private static boolean availabledEl3;
+    static {
         try {
             Class.forName("javax.el.ELProcessor");
-            this.availabledEl3 = true;
+            availabledEl3 = true;
         } catch (ClassNotFoundException e) {
-            this.availabledEl3 = false;
+            availabledEl3 = false;
         }
     }
     
-    /** TLDファイルの定義内容 */
-    private List<Taglib> taglibList = new ArrayList<>();
+    /** 実装クラス */
+    private AbstractExpressionLanguageELImpl impl;
+    
+    
+    public ExpressionLanguageELImpl() {
+        if (availabledEl3) {
+            this.impl = new ExpressionLanguageELImpl3();
+        } else {
+            this.impl = new ExpressionLanguageELImpl2();
+        }
+    }
     
     /**
      * {@inheritDoc}
@@ -54,164 +44,8 @@ public class ExpressionLanguageELImpl implements ExpressionLanguage {
     @Override
     public Object evaluate(final String expression, final Map<String, ?> values) {
         
-        ArgUtils.notEmpty(expression, "expression");
-        ArgUtils.notEmpty(values, "values");
+        return impl.evaluate(expression, values);
         
-        if(availabledEl3) {
-            return evaluateWithEL3(expression, values);
-        } else {
-            return evaluateWithEL2(expression, values);
-        }
-        
-    }
-    
-    /**
-     * EL3.xで評価する
-     * @param expression
-     * @param values
-     * @return
-     */
-    Object evaluateWithEL3(final String expression, final Map<String, ?> values) {
-        
-        try {
-            final ELProcessor elProc = new ELProcessor();
-            
-            final Map<String, Object> beans = new HashMap<String, Object>();
-            for (final Entry<String, ? > entry : values.entrySet()) {
-                if(isFormatter(entry.getKey(), entry.getValue())) {
-                    // Formatterの場合は、ラップクラスを設定する。
-                    beans.put(entry.getKey(), new FormatterWrapper((Formatter) entry.getValue()));
-                } else {
-                    beans.put(entry.getKey(), entry.getValue());
-                }
-            }
-            
-            elProc.getELManager().addBeanNameResolver(new LocalBeanNameResolver(beans));
-            
-            // カスタムタグを登録する。
-            for(Taglib taglib : taglibList) {
-                final String prefix = Utils.trimToEmpty(taglib.getShortName());
-                
-                for(Function function : taglib.getFunctions()) {
-                    final String className = Utils.trimToEmpty(function.getFunctionClass());
-                    final String signature = Utils.trimToEmpty(function.getFunctionSignature());
-                    final String name = Utils.trimToEmpty(function.getName());
-                        
-                    try {
-                        elProc.defineFunction(prefix, name, className, signature);
-                        
-                    } catch(ClassNotFoundException | NoSuchMethodException ex) {
-                        throw new ExpressionEvaluationException(String.format("Faild defined with EL function : [%s:%s].", className, signature), ex);
-                    }
-                }
-            }
-            
-            if(logger.isDebugEnabled()) {
-                logger.debug("Evaluating EL expression: {}", expression);
-            }
-            
-            return elProc.eval(expression);
-        
-        } catch (final ELException ex){
-            throw new ExpressionEvaluationException(String.format("Evaluating [%s] script with EL failed.", expression), ex);
-        }
-    }
-    
-    /**
-     * EL2.xで評価する
-     * @param expression
-     * @param values
-     * @return
-     */
-    Object evaluateWithEL2(final String expression, final Map<String, ?> values) {
-        
-        try {
-            final com.github.mygreen.expression.el.ELProcessor elProc = new com.github.mygreen.expression.el.ELProcessor();
-            
-            for (final Entry<String, ? > entry : values.entrySet()) {
-                if(isFormatter(entry.getKey(), entry.getValue())) {
-                    elProc.setVariable(entry.getKey(), new FormatterWrapper((Formatter) entry.getValue()));
-                } else {
-                    elProc.setVariable(entry.getKey(), entry.getValue());
-                }
-            }
-            
-            // カスタムタグを登録する。
-            for(Taglib taglib : taglibList) {
-                final String prefix = Utils.trimToEmpty(taglib.getShortName());
-                
-                for(Function function : taglib.getFunctions()) {
-                    final String className = Utils.trimToEmpty(function.getFunctionClass());
-                    final String signature = Utils.trimToEmpty(function.getFunctionSignature());
-                    final String name = Utils.trimToEmpty(function.getName());
-                        
-                    try {
-                        elProc.defineFunction(prefix, name, className, signature);
-                        
-                    } catch(ClassNotFoundException | NoSuchMethodException ex) {
-                        throw new ExpressionEvaluationException(String.format("Faild defined with EL function : [%s:%s].", className, signature), ex);
-                    }
-                }
-            }
-            
-            if(logger.isDebugEnabled()) {
-                logger.debug("Evaluating EL expression: {}", expression);
-            }
-            
-            return elProc.eval(expression);        
-        } catch (final ELException ex){
-            throw new ExpressionEvaluationException(String.format("Evaluating [%s] script with EL failed.", expression), ex);
-        }
-        
-    }
-    
-    /**
-     * {@link FormatterWrapper}で囲むべき値かどうか判定する。
-     * @param key
-     * @param value
-     * @return
-     */
-    private boolean isFormatter(final String key, final Object value) {
-        if(!RootResolver.FORMATTER.equals(key)) {
-            return false;
-        }
-        
-        if(value instanceof Formatter) {
-            return true;
-        }
-        
-        return false;
-    }
-    
-    /**
-     * EL3.0用の式中の変数のResolver。
-     * ・存在しない場合はnullを返す。
-     *
-     */
-    private class LocalBeanNameResolver extends BeanNameResolver {
-        
-        private final Map<String, Object> map;
-        
-        public LocalBeanNameResolver(final Map<String, ?> map) {
-            this.map = new HashMap<>(map);
-        }
-        
-        @Override
-        public boolean isNameResolved(final String beanName){
-            // 存在しない場合はnullを返すように、必ずtrueを設定する。
-            return true;
-        }
-        
-        @Override
-        public Object getBean(final String beanName){
-            return map.get( beanName );
-        }
-        
-        @Override
-        public void setBeanValue(String beanName, Object value){
-            map.put(beanName, value );
-        }
-
     }
     
     /**
@@ -222,7 +56,7 @@ public class ExpressionLanguageELImpl implements ExpressionLanguage {
      * @param taglib カスタムタグの定義内容。
      */
     public void register(final Taglib taglib) {
-        this.taglibList.add(taglib);
+        this.impl.register(taglib);
     }
     
 }

--- a/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl2.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl2.java
@@ -1,0 +1,78 @@
+package com.gh.mygreen.xlsmapper.expression;
+
+import java.util.Formatter;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.el.ELException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gh.mygreen.xlsmapper.Utils;
+import com.github.mygreen.expression.el.FormatterWrapper;
+import com.github.mygreen.expression.el.tld.Function;
+import com.github.mygreen.expression.el.tld.Taglib;
+
+
+/**
+ * 標準のEL式(EL2.x)を使用するための実装。
+ * <p>利用する際には、ELのライブラリが必要です。
+ * 
+ * @version 1.5
+ * 
+ */
+public class ExpressionLanguageELImpl2 extends AbstractExpressionLanguageELImpl {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ExpressionLanguageELImpl2.class);
+    
+    /**
+     * EL2.xで評価する
+     * @param expression
+     * @param values
+     * @return
+     */
+    @Override
+    protected Object doEvaluate(final String expression, final Map<String, ?> values) {
+        
+        try {
+            final com.github.mygreen.expression.el.ELProcessor elProc = new com.github.mygreen.expression.el.ELProcessor();
+            
+            for (final Entry<String, ? > entry : values.entrySet()) {
+                if(isFormatter(entry.getKey(), entry.getValue())) {
+                    elProc.setVariable(entry.getKey(), new FormatterWrapper((Formatter) entry.getValue()));
+                } else {
+                    elProc.setVariable(entry.getKey(), entry.getValue());
+                }
+            }
+            
+            // カスタムタグを登録する。
+            for(Taglib taglib : taglibList) {
+                final String prefix = Utils.trimToEmpty(taglib.getShortName());
+                
+                for(Function function : taglib.getFunctions()) {
+                    final String className = Utils.trimToEmpty(function.getFunctionClass());
+                    final String signature = Utils.trimToEmpty(function.getFunctionSignature());
+                    final String name = Utils.trimToEmpty(function.getName());
+                        
+                    try {
+                        elProc.defineFunction(prefix, name, className, signature);
+                        
+                    } catch(ClassNotFoundException | NoSuchMethodException ex) {
+                        throw new ExpressionEvaluationException(String.format("Faild defined with EL function : [%s:%s].", className, signature), ex);
+                    }
+                }
+            }
+            
+            if(logger.isDebugEnabled()) {
+                logger.debug("Evaluating EL expression: {}", expression);
+            }
+            
+            return elProc.eval(expression);        
+        } catch (final ELException ex){
+            throw new ExpressionEvaluationException(String.format("Evaluating [%s] script with EL failed.", expression), ex);
+        }
+        
+    }
+    
+}

--- a/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl3.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/expression/ExpressionLanguageELImpl3.java
@@ -1,0 +1,116 @@
+package com.gh.mygreen.xlsmapper.expression;
+
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.el.BeanNameResolver;
+import javax.el.ELException;
+import javax.el.ELProcessor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gh.mygreen.xlsmapper.Utils;
+import com.github.mygreen.expression.el.FormatterWrapper;
+import com.github.mygreen.expression.el.tld.Function;
+import com.github.mygreen.expression.el.tld.Taglib;
+
+
+/**
+ * 標準のEL式(EL3.x)を使用するための実装。
+ * <p>利用する際には、ELのライブラリが必要です。
+ * 
+ * @version 1.5
+ * 
+ */
+public class ExpressionLanguageELImpl3 extends AbstractExpressionLanguageELImpl {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ExpressionLanguageELImpl3.class);
+    
+    /**
+     * EL3.xで評価する
+     * @param expression
+     * @param values
+     * @return
+     */
+    @Override
+    protected Object doEvaluate(final String expression, final Map<String, ?> values) {
+        
+        try {
+            final ELProcessor elProc = new ELProcessor();
+            
+            final Map<String, Object> beans = new HashMap<String, Object>();
+            for (final Entry<String, ? > entry : values.entrySet()) {
+                if(isFormatter(entry.getKey(), entry.getValue())) {
+                    // Formatterの場合は、ラップクラスを設定する。
+                    beans.put(entry.getKey(), new FormatterWrapper((Formatter) entry.getValue()));
+                } else {
+                    beans.put(entry.getKey(), entry.getValue());
+                }
+            }
+            
+            elProc.getELManager().addBeanNameResolver(new LocalBeanNameResolver(beans));
+            
+            // カスタムタグを登録する。
+            for(Taglib taglib : taglibList) {
+                final String prefix = Utils.trimToEmpty(taglib.getShortName());
+                
+                for(Function function : taglib.getFunctions()) {
+                    final String className = Utils.trimToEmpty(function.getFunctionClass());
+                    final String signature = Utils.trimToEmpty(function.getFunctionSignature());
+                    final String name = Utils.trimToEmpty(function.getName());
+                        
+                    try {
+                        elProc.defineFunction(prefix, name, className, signature);
+                        
+                    } catch(ClassNotFoundException | NoSuchMethodException ex) {
+                        throw new ExpressionEvaluationException(String.format("Faild defined with EL function : [%s:%s].", className, signature), ex);
+                    }
+                }
+            }
+            
+            if(logger.isDebugEnabled()) {
+                logger.debug("Evaluating EL expression: {}", expression);
+            }
+            
+            return elProc.eval(expression);
+        
+        } catch (final ELException ex){
+            throw new ExpressionEvaluationException(String.format("Evaluating [%s] script with EL failed.", expression), ex);
+        }
+    }
+    
+    /**
+     * EL3.0用の式中の変数のResolver。
+     * ・存在しない場合はnullを返す。
+     *
+     */
+    private class LocalBeanNameResolver extends BeanNameResolver {
+        
+        private final Map<String, Object> map;
+        
+        public LocalBeanNameResolver(final Map<String, ?> map) {
+            this.map = new HashMap<>(map);
+        }
+        
+        @Override
+        public boolean isNameResolved(final String beanName){
+            // 存在しない場合はnullを返すように、必ずtrueを設定する。
+            return true;
+        }
+        
+        @Override
+        public Object getBean(final String beanName){
+            return map.get( beanName );
+        }
+        
+        @Override
+        public void setBeanValue(String beanName, Object value){
+            map.put(beanName, value );
+        }
+        
+    }
+    
+}

--- a/src/test/java/com/gh/mygreen/xlsmapper/expression/ExpresionLanguageELTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/expression/ExpresionLanguageELTest.java
@@ -28,11 +28,11 @@ import com.github.mygreen.expression.el.tld.TldLoader;
  */
 public class ExpresionLanguageELTest {
     
-    private ExpressionLanguageELImpl el;
+    private AbstractExpressionLanguageELImpl el;
     
     @Before
     public void setUp() throws Exception {
-        this.el = new ExpressionLanguageELImpl();
+        this.el = new ExpressionLanguageELImpl3();
     }
     
     @After
@@ -46,7 +46,7 @@ public class ExpresionLanguageELTest {
         
         Map<String, Object> vars = new HashMap<>();
         
-        String eval = (String) el.evaluateWithEL3(expression, vars);
+        String eval = (String) el.evaluate(expression, vars);
         assertThat(eval, is("空です"));
 //        System.out.println(eval);
         
@@ -64,7 +64,7 @@ public class ExpresionLanguageELTest {
         vars.put("formatter", new FormatterWrapper(Locale.getDefault()));
 //        vars.put("formatter", new Formatter());
         
-        String eval = (String) el.evaluateWithEL3(expression, vars);
+        String eval = (String) el.evaluate(expression, vars);
         assertThat(eval, is("2015/04/15"));
 //        System.out.println(eval);
         
@@ -78,7 +78,7 @@ public class ExpresionLanguageELTest {
         Map<String, Object> vars = new HashMap<>();
         vars.put("list", Arrays.asList(1, 2, 3, 4, 5, 6));
         
-        long eval = (long) el.evaluateWithEL3(expression, vars);
+        long eval = (long) el.evaluate(expression, vars);
         assertThat(eval, is(21L));
 //        System.out.println(val);
         
@@ -95,7 +95,7 @@ public class ExpresionLanguageELTest {
         vars.put("validatedValue", 12.34);
         vars.put("formatter", new FormatterWrapper(Locale.getDefault()));
         
-        String eval = (String) el.evaluateWithEL3(expression, vars);
+        String eval = (String) el.evaluate(expression, vars);
         assertThat(eval, is("Helo World}12.3"));
 //        System.out.println(eval);
         
@@ -111,14 +111,14 @@ public class ExpresionLanguageELTest {
         vars.put("columnNumber", 6);
         vars.put("rowNumber", 10);
         
-        String eval1 = (String) el.evaluateWithEL3(expression, vars);
+        String eval1 = (String) el.evaluate(expression, vars);
         assertThat(eval1, is(""));
         
         vars.clear();
         vars.put("columnNumber", 7);
         vars.put("rowNumber", 10);
         
-        String eval2 = (String) el.evaluateWithEL3(expression, vars);
+        String eval2 = (String) el.evaluate(expression, vars);
         assertThat(eval2, is("COUNTIF(D10:F10, \"出席\")"));
 //        System.out.println(eval);
         
@@ -138,7 +138,7 @@ public class ExpresionLanguageELTest {
         Map<String, Object> vars = new HashMap<>();
         vars.put("columnNumber", 1);
         
-        String eval = (String) el.evaluateWithEL3(expression, vars);
+        String eval = (String) el.evaluate(expression, vars);
         assertThat(eval, is("A"));
         
     }


### PR DESCRIPTION
ExpressionLanguageELImpl が暗黙的に javax.el.BeanNameResolver に依存しており、
EL2.x のみを使用している時に ExpressionLanguageELImpl をインスタンス化しようとすると
NoClassDefFoundError がスローされるため、EL2.x 用の実装クラスと EL3.x 用の実装クラスを分離しました。
