### PR TITLE
excel-cellformatterの0.9.2を使う

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,18 +11,18 @@
 	<description><![CDATA[
 XlsMapper is Java Library for mapping Excel sheets to POJO.
 ]]></description>
-	
+
 	<issueManagement>
 		<system>github</system>
 		<url>https://github.com/mygreen/xlsmapper/issues</url>
 	</issueManagement>
-	
+
 	<scm>
 		<connection>scm:git:ssh://github.com/mygreen/xlsmapper.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/mygreen/xlsmapper.git</developerConnection>
 		<url>https://github.com/mygreen/xlsmapper</url>
 	</scm>
-	
+
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
@@ -36,19 +36,19 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
-	
+
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
-	
+
 	<organization>
 		<name>mygreen</name>
 		<url>http://mygreen.github.io/xlsmapper/</url>
 	</organization>
-	
+
 	<developers>
 		<developer>
 			<id>mygreen</id>
@@ -59,7 +59,7 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 			</roles>
 		</developer>
 	</developers>
-	
+
 	<properties>
 		<java.version>1.7</java.version>
 		<poi.version>3.15</poi.version>
@@ -67,7 +67,7 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 	</properties>
 	<build>
 		<extensions>
-			
+
 		</extensions>
 		<resources>
 			<resource>
@@ -166,7 +166,7 @@ $(document).ready(function() {
 					<downloadSources>true</downloadSources>
 				</configuration>
 			</plugin>
-			
+
 			<plugin>
 				<artifactId>maven-site-plugin</artifactId>
 				<configuration>
@@ -209,7 +209,7 @@ $(document).ready(function() {
 					</execution>
 				</executions>
 			</plugin>
-			
+
 		</plugins>
 	</build>
 	<repositories>
@@ -234,7 +234,7 @@ $(document).ready(function() {
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<!-- Excel -->
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -249,9 +249,9 @@ $(document).ready(function() {
 		<dependency>
 			<groupId>com.github.mygreen</groupId>
 			<artifactId>excel-cellformatter</artifactId>
-			<version>0.9.1</version>
+			<version>0.9.2</version>
 		</dependency>
-		
+
 		<!-- Logger -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -270,7 +270,7 @@ $(document).ready(function() {
 			<version>1.2.14</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<!-- 式言語 -->
 		<dependency>
 			<groupId>com.github.mygreen</groupId>
@@ -288,14 +288,14 @@ $(document).ready(function() {
 			<artifactId>ognl</artifactId>
 			<version>3.0.8</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.mvel</groupId>
 			<artifactId>mvel2</artifactId>
 			<version>2.2.2.Final</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<!-- EL 2.x
 		<dependency>
 			<groupId>org.glassfish.web</groupId>
@@ -309,13 +309,13 @@ $(document).ready(function() {
 			<artifactId>javax.el</artifactId>
 			<version>3.0.1-b08</version>
 		</dependency>
-		 
+
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-jexl</artifactId>
 			<version>2.1.1</version>
 		</dependency>
-		
+
 		<!-- Bean Validation 1.1 系を利用する -->
 		<dependency>
 			<groupId>javax.validation</groupId>
@@ -329,7 +329,7 @@ $(document).ready(function() {
 			<version>5.1.3.Final</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<!-- Spring -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -343,7 +343,7 @@ $(document).ready(function() {
 			<version>3.2.11.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 	</dependencies>
 	<reporting>
 		<plugins>
@@ -377,7 +377,7 @@ $(document).ready(function() {
 </script>
 ]]>
 					</header>
-					
+
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,18 +11,18 @@
 	<description><![CDATA[
 XlsMapper is Java Library for mapping Excel sheets to POJO.
 ]]></description>
-
+	
 	<issueManagement>
 		<system>github</system>
 		<url>https://github.com/mygreen/xlsmapper/issues</url>
 	</issueManagement>
-
+	
 	<scm>
 		<connection>scm:git:ssh://github.com/mygreen/xlsmapper.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/mygreen/xlsmapper.git</developerConnection>
 		<url>https://github.com/mygreen/xlsmapper</url>
 	</scm>
-
+	
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
@@ -36,19 +36,19 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
-
+	
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
-
+	
 	<organization>
 		<name>mygreen</name>
 		<url>http://mygreen.github.io/xlsmapper/</url>
 	</organization>
-
+	
 	<developers>
 		<developer>
 			<id>mygreen</id>
@@ -59,7 +59,7 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 			</roles>
 		</developer>
 	</developers>
-
+	
 	<properties>
 		<java.version>1.7</java.version>
 		<poi.version>3.15</poi.version>
@@ -67,7 +67,7 @@ XlsMapper is Java Library for mapping Excel sheets to POJO.
 	</properties>
 	<build>
 		<extensions>
-
+			
 		</extensions>
 		<resources>
 			<resource>
@@ -166,7 +166,7 @@ $(document).ready(function() {
 					<downloadSources>true</downloadSources>
 				</configuration>
 			</plugin>
-
+			
 			<plugin>
 				<artifactId>maven-site-plugin</artifactId>
 				<configuration>
@@ -209,7 +209,7 @@ $(document).ready(function() {
 					</execution>
 				</executions>
 			</plugin>
-
+			
 		</plugins>
 	</build>
 	<repositories>
@@ -234,7 +234,7 @@ $(document).ready(function() {
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
-
+		
 		<!-- Excel -->
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -251,7 +251,7 @@ $(document).ready(function() {
 			<artifactId>excel-cellformatter</artifactId>
 			<version>0.9.2</version>
 		</dependency>
-
+		
 		<!-- Logger -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -270,7 +270,7 @@ $(document).ready(function() {
 			<version>1.2.14</version>
 			<scope>test</scope>
 		</dependency>
-
+		
 		<!-- 式言語 -->
 		<dependency>
 			<groupId>com.github.mygreen</groupId>
@@ -288,14 +288,14 @@ $(document).ready(function() {
 			<artifactId>ognl</artifactId>
 			<version>3.0.8</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>org.mvel</groupId>
 			<artifactId>mvel2</artifactId>
 			<version>2.2.2.Final</version>
 			<scope>provided</scope>
 		</dependency>
-
+		
 		<!-- EL 2.x
 		<dependency>
 			<groupId>org.glassfish.web</groupId>
@@ -309,13 +309,13 @@ $(document).ready(function() {
 			<artifactId>javax.el</artifactId>
 			<version>3.0.1-b08</version>
 		</dependency>
-
+		 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-jexl</artifactId>
 			<version>2.1.1</version>
 		</dependency>
-
+		
 		<!-- Bean Validation 1.1 系を利用する -->
 		<dependency>
 			<groupId>javax.validation</groupId>
@@ -329,7 +329,7 @@ $(document).ready(function() {
 			<version>5.1.3.Final</version>
 			<scope>provided</scope>
 		</dependency>
-
+		
 		<!-- Spring -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -343,7 +343,7 @@ $(document).ready(function() {
 			<version>3.2.11.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
-
+		
 	</dependencies>
 	<reporting>
 		<plugins>
@@ -377,7 +377,7 @@ $(document).ready(function() {
 </script>
 ]]>
 					</header>
-
+					
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
excel-cellformatterを更新して頂きましたが、xlsmapperは更新前のバージョンを読み込みます。更新して頂いた最新のバージョン(0.9.2)を読み込むように修正しました