### PR TITLE
Jakarta Bean Validation 3.0対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,28 @@ $(document).ready(function() {
 			<version>3.0.1-b08</version>
 			<scope>provided</scope>
 		</dependency>
+		
+		<!-- Jakarta Bean Validation (Java11以上が必要) -->
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<!--
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>8.0.2.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.expressly</groupId>
+			<artifactId>expressly</artifactId>
+			<version>5.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+		-->
 
 		<!-- Spring -->
 		<dependency>
@@ -532,6 +554,14 @@ $(document).ready(function() {
 			<artifactId>spring-test</artifactId>
 			<version>${spring.version}</version>
 			<scope>test</scope>
+		</dependency>
+
+		<!-- JAXB(Java9以降の場合は必要) -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/gh/mygreen/xlsmapper/localization/ResourceBundleMessageResolver.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/localization/ResourceBundleMessageResolver.java
@@ -111,6 +111,7 @@ public class ResourceBundleMessageResolver implements MessageResolver {
             return false;
         }
         
+        // 後から追加したリソースを優先するために、先頭に追加する。
         messageBundles.addFirst(resourceBundle);
         final List<String> keys = new ArrayList<String>();
         

--- a/src/main/java/com/gh/mygreen/xlsmapper/localization/SheetValidationMessages.properties
+++ b/src/main/java/com/gh/mygreen/xlsmapper/localization/SheetValidationMessages.properties
@@ -124,12 +124,38 @@ javax.validation.constraints.Positive.message={cellContext}の値'${empty(fieldF
 javax.validation.constraints.PositiveOrZero.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、0以上の値を設定してください。
 javax.validation.constraints.Email.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、E-mail形式で設定してください。
 
+## Jakarta Bean Validation 3.0のメッセージ
+jakarta.validation.constraints.AssertFalse.message={javax.validation.constraints.AssertFalse.message}
+jakarta.validation.constraints.AssertTrue.message={javax.validation.constraints.AssertTrue.message}
+jakarta.validation.constraints.DecimalMax.message={javax.validation.constraints.DecimalMax.message}
+jakarta.validation.constraints.DecimalMin.message={javax.validation.constraints.DecimalMin.message}
+jakarta.validation.constraints.Digits.message={javax.validation.constraints.Digits.message}
+jakarta.validation.constraints.Email.message={javax.validation.constraints.Email.message}
+jakarta.validation.constraints.Future.message={javax.validation.constraints.Future.message}
+jakarta.validation.constraints.FutureOrPresent.message={javax.validation.constraints.FutureOrPresent.message}
+jakarta.validation.constraints.Max.message={javax.validation.constraints.Max.message}
+jakarta.validation.constraints.Min.message={javax.validation.constraints.Min.message}
+jakarta.validation.constraints.Negative.message={javax.validation.constraints.Negative.message}
+jakarta.validation.constraints.NegativeOrZero.message={javax.validation.constraints.NegativeOrZero.message}
+jakarta.validation.constraints.NotBlank.message={javax.validation.constraints.NotBlank.message}
+jakarta.validation.constraints.NotEmpty.message={javax.validation.constraints.NotEmpty.message}
+jakarta.validation.constraints.NotNull.message={javax.validation.constraints.NotNull.message}
+jakarta.validation.constraints.Null.message={javax.validation.constraints.Null.message}
+jakarta.validation.constraints.Past.message={javax.validation.constraints.Past.message}
+jakarta.validation.constraints.PastOrPresent.message={javax.validation.constraints.PastOrPresent.message}
+jakarta.validation.constraints.Pattern.message={javax.validation.constraints.Pattern.message}
+jakarta.validation.constraints.Positive.message={javax.validation.constraints.Positive.message}
+jakarta.validation.constraints.PositiveOrZero.message={javax.validation.constraints.PositiveOrZero.message}
+jakarta.validation.constraints.Size.message={javax.validation.constraints.Size.message}
+
 
 ## Hibernate Validatorのエラーメッセージ
 org.hibernate.validator.constraints.CreditCardNumber.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、不正なクレジットカードの番号です。
 org.hibernate.validator.constraints.EAN.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、不正な{type}のコードです。
+org.hibernate.validator.constraints.ISBN.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、不正な ISBN です。
 org.hibernate.validator.constraints.Email.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、E-mail形式で設定してください。
 org.hibernate.validator.constraints.Length.message={cellContext}の文字長'${validatedValue.length()}'は、{min}～{max}の間で設定してください。
+org.hibernate.validator.constraints.CodePointLength.message={cellContext}の文字長'${validatedValue.length()}'は、{min}～{max}の間で設定してください。
 org.hibernate.validator.constraints.LuhnCheck.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、Luhn Module 10 チェックサムの値が不正です。
 org.hibernate.validator.constraints.Mod10Check.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、Module 10 チェックサムの値が不正です。
 org.hibernate.validator.constraints.Mod11Check.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、Luhn Module 11 チェックサムの値が不正です。
@@ -140,6 +166,7 @@ org.hibernate.validator.constraints.ParametersScriptAssert.message={cellContext}
 org.hibernate.validator.constraints.Range.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、{min}から{max}の間の値を設定してください。
 org.hibernate.validator.constraints.SafeHtml.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、スクリプトを含んでいる安全でない可能性があります。
 org.hibernate.validator.constraints.ScriptAssert.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、スクリプトの式"{script}"がtrueを返しませんでした。
+org.hibernate.validator.constraints.UniqueElements.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}' の要素は、全てユニークにしてください
 org.hibernate.validator.constraints.URL.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、不正なURLの形式です。
 
 org.hibernate.validator.constraints.br.CNPJ.message={cellContext}の値'${empty(fieldFormatter) ? validatedValue : fieldFormatter.format(validatedValue)}'は、法人税金支払番号（CNPJ）として不正な書式です。

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
@@ -13,7 +13,7 @@ import jakarta.validation.metadata.ConstraintDescriptor;
 
 /**
  * XlsMapperの{@link MessageInterpolator}とBeanValidationの{@link jakarta.validation.MessageInterpolator}のAdaptor。
- * <p>BeanValidatorのメッセ－時処理時、特に式言語の実装切り替えする場合に利用する。
+ * <p>BeanValidatorのメッセ－ジ処理時、特に式言語の実装切り替えする場合に利用する。
  *
  * @since 2.3
  * @author T.TSUCHIE

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaMessageInterpolatorAdapter.java
@@ -1,0 +1,68 @@
+package com.gh.mygreen.xlsmapper.validation.beanvalidation;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import com.gh.mygreen.xlsmapper.localization.MessageInterpolator;
+import com.gh.mygreen.xlsmapper.localization.MessageResolver;
+import com.gh.mygreen.xlsmapper.util.ArgUtils;
+
+import jakarta.validation.metadata.ConstraintDescriptor;
+
+
+/**
+ * XlsMapperの{@link MessageInterpolator}とBeanValidationの{@link jakarta.validation.MessageInterpolator}のAdaptor。
+ * <p>BeanValidatorのメッセ－時処理時、特に式言語の実装切り替えする場合に利用する。
+ *
+ * @since 2.3
+ * @author T.TSUCHIE
+ *
+ */
+public class JakartaMessageInterpolatorAdapter implements jakarta.validation.MessageInterpolator {
+    
+    private final MessageResolver messageResolver;
+    
+    private final MessageInterpolator sheetMessageInterpolator;
+    
+    public JakartaMessageInterpolatorAdapter(final MessageResolver messageResolver, 
+            final MessageInterpolator sheetMessageInterpolator) {
+        ArgUtils.notNull(messageResolver, "messageResolver");
+        ArgUtils.notNull(sheetMessageInterpolator, "sheetMessageInterpolator");
+        this.messageResolver = messageResolver;
+        this.sheetMessageInterpolator = sheetMessageInterpolator;
+    }
+    
+    @Override
+    public String interpolate(final String messageTemplate, final Context context) {
+        return sheetMessageInterpolator.interpolate(messageTemplate, createMessageVars(context), true, messageResolver);
+    }
+    
+    @Override
+    public String interpolate(final String messageTemplate, final Context context, final Locale locale) {
+        return sheetMessageInterpolator.interpolate(messageTemplate, createMessageVars(context), true, messageResolver);
+    }
+    
+    /**
+     * メッセージ中で利用可能な変数を作成する
+     * @param context コンテキスト
+     * @return メッセージ変数のマップ
+     */
+    protected Map<String, Object> createMessageVars(final Context context) {
+        
+        final Map<String, Object> vars = new HashMap<String, Object>();
+        
+        final ConstraintDescriptor<?> descriptor = context.getConstraintDescriptor();
+        for(Map.Entry<String, Object> entry : descriptor.getAttributes().entrySet()) {
+            final String attrName = entry.getKey();
+            final Object attrValue = entry.getValue();
+            
+            vars.put(attrName, attrValue);
+        }
+        
+        // 検証対象の値
+        vars.computeIfAbsent("validatedValue", key -> context.getValidatedValue());
+        
+        return vars;
+    }
+}

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
@@ -1,0 +1,276 @@
+package com.gh.mygreen.xlsmapper.validation.beanvalidation;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.hibernate.validator.internal.engine.path.NodeImpl;
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.gh.mygreen.xlsmapper.fieldaccessor.LabelGetterFactory;
+import com.gh.mygreen.xlsmapper.fieldaccessor.PositionGetterFactory;
+import com.gh.mygreen.xlsmapper.localization.MessageInterpolator;
+import com.gh.mygreen.xlsmapper.localization.ResourceBundleMessageResolver;
+import com.gh.mygreen.xlsmapper.util.ArgUtils;
+import com.gh.mygreen.xlsmapper.util.CellPosition;
+import com.gh.mygreen.xlsmapper.util.Utils;
+import com.gh.mygreen.xlsmapper.validation.FieldError;
+import com.gh.mygreen.xlsmapper.validation.ObjectValidator;
+import com.gh.mygreen.xlsmapper.validation.SheetBindingErrors;
+import com.gh.mygreen.xlsmapper.validation.fieldvalidation.FieldFormatter;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.metadata.ConstraintDescriptor;
+
+
+/**
+ * Jakarata Bean Validaion 3.0/3.1 を利用したValidator.
+ * 
+ * @version 2.3
+ * @author T.TSUCHIE
+ *
+ */
+public class JakartaSheetBeanValidator implements ObjectValidator<Object> {
+    
+    private static final Logger logger = LoggerFactory.getLogger(JakartaSheetBeanValidator.class);
+    
+    /**
+     * BeanValidationのアノテーションの属性で、メッセージ中の変数から除外するもの。
+     * <p>メッセージの再構築を行う際に必要
+     */
+    private static final Set<String> EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES;
+    static {
+        Set<String> set = new HashSet<String>(3);
+        set.add("message");
+        set.add("groups");
+        set.add("payload");
+        
+        EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES = Collections.unmodifiableSet(set);
+    }
+    
+    private final Validator targetValidator;
+    
+    public JakartaSheetBeanValidator(final Validator targetValidator) {
+        ArgUtils.notNull(targetValidator, "targetValidator");
+        this.targetValidator = targetValidator;
+    }
+    
+    public JakartaSheetBeanValidator() {
+        this.targetValidator = createDefaultValidator();
+    }
+    
+    /**
+     * Bean Validatorのデフォルトのインスタンスを取得する。
+     * @return
+     */
+    protected Validator createDefaultValidator() {
+        
+        final ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
+                .messageInterpolator(new JakartaMessageInterpolatorAdapter(new ResourceBundleMessageResolver(), new MessageInterpolator()))
+                .buildValidatorFactory();
+        final Validator validator = validatorFactory.usingContext()
+                .getValidator();
+        
+        return validator;
+    }
+    
+    /**
+     * BeanValidationのValidatorを取得する。
+     * @return
+     */
+    public Validator getTargetValidator() {
+        return targetValidator;
+    }
+    
+    /**
+     * グループを指定して検証を実行する。
+     * @param targetObj 検証対象のオブジェクト。
+     * @param errors エラーオブジェクト
+     * @param groups BeanValiationのグループのクラス
+     */
+    @Override
+    public void validate(final Object targetObj, final SheetBindingErrors<?> errors, final Class<?>... groups) {
+        
+        ArgUtils.notNull(targetObj, "targetObj");
+        ArgUtils.notNull(errors, "errors");
+        
+        processConstraintViolation(getTargetValidator().validate(targetObj, groups), errors);
+        
+    }
+    
+    /**
+     * BeanValidationの検証結果をSheet用のエラーに変換する
+     * @param violations BeanValidationの検証結果
+     * @param errors シートのエラー
+     */
+    protected void processConstraintViolation(final Set<ConstraintViolation<Object>> violations,
+            final SheetBindingErrors<?> errors) {
+        
+        for(ConstraintViolation<Object> violation : violations) {
+            
+            final String fieldName = violation.getPropertyPath().toString();
+            final Optional<FieldError> fieldError = errors.getFirstFieldError(fieldName);
+            
+            if(fieldError.isPresent() && fieldError.get().isConversionFailure()) {
+                // 型変換エラーが既存のエラーにある場合は、処理をスキップする。
+                continue;
+            }
+            
+            final ConstraintDescriptor<?> cd = violation.getConstraintDescriptor();
+            
+            final String[] errorCodes = determineErrorCode(cd);
+            
+            final Map<String, Object> errorVars = createVariableForConstraint(cd);
+            
+            final String nestedPath = errors.buildFieldPath(fieldName);
+            if(Utils.isEmpty(nestedPath)) {
+                // オブジェクトエラーの場合
+                errors.createGlobalError(errorCodes)
+                    .variables(errorVars)
+                    .defaultMessage(violation.getMessageTemplate())
+                    .buildAndAddError();
+                
+            } else {
+                // フィールドエラーの場合
+                
+                // 親のオブジェクトから、セルの座標を取得する
+                final Object parentObj = violation.getLeafBean();
+                final Path path = violation.getPropertyPath();
+                Optional<CellPosition> cellAddress = Optional.empty();
+                Optional<String> label = Optional.empty();
+                if(Path.class.isAssignableFrom(PathImpl.class)) {
+                    final String pathNodeName = getPathNodeName(path);
+                    cellAddress = new PositionGetterFactory().create(parentObj.getClass(), pathNodeName)
+                            .map(getter -> getter.get(parentObj)).orElse(Optional.empty());
+                    
+                    label = new LabelGetterFactory().create(parentObj.getClass(), pathNodeName)
+                            .map(getter -> getter.get(parentObj)).orElse(Optional.empty());
+                    
+                }
+                
+                // フィールドフォーマッタ
+                Class<?> fieldType = errors.getFieldType(nestedPath);
+                if(fieldType != null) {
+                    FieldFormatter<?> fieldFormatter = errors.findFieldFormatter(nestedPath, fieldType);
+                    if(fieldFormatter != null) {
+                        errorVars.putIfAbsent("fieldFormatter", fieldFormatter);
+                    }
+                }
+                
+                // 実際の値を取得する
+                errorVars.putIfAbsent("validatedValue", violation.getInvalidValue());
+                
+                errors.createFieldError(fieldName, errorCodes)
+                    .variables(errorVars)
+                    .address(cellAddress)
+                    .label(label)
+                    .defaultMessage(violation.getMessageTemplate())
+                    .buildAndAddError();
+                
+            }
+            
+        }
+        
+    }
+    
+    /**
+     * BeanValidationのPathの名称を取得する。
+     * <p>Hibernateのバージョンにより、パッケージが異なるのでリフレクションで取得する。
+     * 
+     * @param path パス
+     * @return 名称
+     */
+    private String getPathNodeName(final Path path) {
+        
+        try {
+            Method getLeafNodeMethod = PathImpl.class.getMethod("getLeafNode");
+            Object leafNodeObj = getLeafNodeMethod.invoke(path);
+            if(leafNodeObj == null) {
+                return null;
+            }
+            
+            Method getNodeNameMethod = NodeImpl.class.getMethod("getName");
+            Object nodeName = getNodeNameMethod.invoke(leafNodeObj);
+            return nodeName != null ? nodeName.toString() : null;
+            
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new RuntimeException("fail PathImple.getLeafNode().getName()", e);
+        }
+        
+    }
+    
+    /**
+     * エラーコードを決定する。
+     * <p>※ユーザ指定メッセージの場合はエラーコードは空。</p>
+     * 
+     * @since 2.3
+     * @param descriptor フィールド情報
+     * @return エラーコード
+     */
+    protected String[] determineErrorCode(final ConstraintDescriptor<?> descriptor) {
+        
+     // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
+        String defaultMessage = null;
+        try {
+            Method messageMethod = descriptor.getAnnotation().annotationType().getMethod("message");
+            messageMethod.setAccessible(true);
+            defaultMessage = Objects.toString(messageMethod.getDefaultValue(), null);
+        } catch (NoSuchMethodException | SecurityException e) {
+            logger.warn("Fail getting annotation's attribute 'message' for " + descriptor.getAnnotation().annotationType().getSimpleName() , e);
+        }
+        
+        if(!descriptor.getMessageTemplate().equals(defaultMessage)) {
+            /*
+             * アノテーション属性「message」の値がデフォルト値から変更されている場合は、
+             * ユーザー指定メッセージとして判断し、エラーコードは空にしてユーザー指定メッセージを優先させる。
+             */
+            return new String[]{};
+            
+        } else {
+            // アノテーションのクラス名をもとに生成する。
+            return new String[]{
+                    descriptor.getAnnotation().annotationType().getSimpleName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName(),
+                    descriptor.getAnnotation().annotationType().getCanonicalName() + ".message"
+            };
+        }
+    }
+    
+    /**
+     * BeanValidationのアノテーションの値を元に、メッセージ変数を作成する。
+     * @param descriptor
+     * @return メッセージ変数
+     */
+    protected Map<String, Object> createVariableForConstraint(final ConstraintDescriptor<?> descriptor) {
+        
+        final Map<String, Object> vars = new HashMap<String, Object>();
+        
+        for(Map.Entry<String, Object> entry : descriptor.getAttributes().entrySet()) {
+            final String attrName = entry.getKey();
+            final Object attrValue = entry.getValue();
+            
+            // メッセージ変数で必要ないものを除外する
+            if(EXCLUDE_MESSAGE_ANNOTATION_ATTRIBUTES.contains(attrName)) {
+                continue;
+            }
+            
+            vars.put(attrName, attrValue);
+        }
+        
+        return vars;
+        
+    }
+    
+}

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
@@ -36,9 +36,9 @@ import jakarta.validation.metadata.ConstraintDescriptor;
 
 
 /**
- * Jakarata Bean Validaion 3.0/3.1 を利用したValidator.
+ * Jakarta Bean Validaion 3.0/3.1 を利用したValidator.
  * 
- * @version 2.3
+ * @since 2.3
  * @author T.TSUCHIE
  *
  */
@@ -72,8 +72,8 @@ public class JakartaSheetBeanValidator implements ObjectValidator<Object> {
     }
     
     /**
-     * Bean Validatorのデフォルトのインスタンスを取得する。
-     * @return
+     * Bean Validaion のデフォルトのインスタンスを作成します。
+     * @return Validatorのインスタンス。
      */
     protected Validator createDefaultValidator() {
         
@@ -87,8 +87,8 @@ public class JakartaSheetBeanValidator implements ObjectValidator<Object> {
     }
     
     /**
-     * BeanValidationのValidatorを取得する。
-     * @return
+     * Bean ValidationのValidatorを取得する。
+     * @return Validatorのインスタンス。
      */
     public Validator getTargetValidator() {
         return targetValidator;

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidator.java
@@ -221,7 +221,7 @@ public class JakartaSheetBeanValidator implements ObjectValidator<Object> {
      */
     protected String[] determineErrorCode(final ConstraintDescriptor<?> descriptor) {
         
-     // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
+        // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
         String defaultMessage = null;
         try {
             Method messageMethod = descriptor.getAnnotation().annotationType().getMethod("message");

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/MessageInterpolatorAdapter.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/MessageInterpolatorAdapter.java
@@ -13,7 +13,7 @@ import com.gh.mygreen.xlsmapper.util.ArgUtils;
 
 /**
  * XlsMapperの{@link MessageInterpolator}とBeanValidationの{@link javax.validation.MessageInterpolator}のAdaptor。
- * <p>BeanValidatorのメッセ－時処理時、特に式言語の実装切り替えする場合に利用する。
+ * <p>BeanValidatorのメッセ－ジ処理時、特に式言語の実装切り替えする場合に利用する。
  *
  * @author T.TSUCHIE
  *

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidator.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidator.java
@@ -36,9 +36,9 @@ import com.gh.mygreen.xlsmapper.validation.fieldvalidation.FieldFormatter;
 
 
 /**
- * BeanValidaion JSR-303(ver.1.0)/JSR-349(ver.1.1)/JSR-380()ver.2.0を利用したValidator.
+ * Bean Validaion JSR-303(ver.1.0)/JSR-349(ver.1.1)/JSR-380(ver.2.0)を利用したValidator.
  * 
- * @version 2.0
+ * @version 2.3
  * @author T.TSUCHIE
  *
  */
@@ -72,8 +72,8 @@ public class SheetBeanValidator implements ObjectValidator<Object> {
     }
     
     /**
-     * Bean Validatorのデフォルトのインスタンスを取得する。
-     * @return
+     * Bean Validaion のデフォルトのインスタンスを作成する。
+     * @return Validatorのインスタンス。
      */
     protected Validator createDefaultValidator() {
         
@@ -87,8 +87,8 @@ public class SheetBeanValidator implements ObjectValidator<Object> {
     }
     
     /**
-     * BeanValidationのValidatorを取得する。
-     * @return
+     * Bean ValidationのValidatorを取得する。
+     * @return Validatorのインスタンス。
      */
     public Validator getTargetValidator() {
         return targetValidator;

--- a/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidator.java
+++ b/src/main/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidator.java
@@ -221,7 +221,7 @@ public class SheetBeanValidator implements ObjectValidator<Object> {
      */
     protected String[] determineErrorCode(final ConstraintDescriptor<?> descriptor) {
         
-     // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
+        // バリデーション用アノテーションから属性「message」のでデフォルト値を取得し、変更されているかどう比較する。
         String defaultMessage = null;
         try {
             Method messageMethod = descriptor.getAnnotation().annotationType().getMethod("message");

--- a/src/test/java/com/gh/mygreen/xlsmapper/sample/attendance/AttendanceTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/sample/attendance/AttendanceTest.java
@@ -1,8 +1,7 @@
 package com.gh.mygreen.xlsmapper.sample.attendance;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,14 +47,15 @@ public class AttendanceTest {
     public void setupBefore() {
 
         // BeanValidatorの式言語の実装を独自のものにする。
-        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-        Validator validator = validatorFactory.usingContext()
+        ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
                 .messageInterpolator(new MessageInterpolatorAdapter(
                         // メッセージリソースの取得方法を切り替える
                         new ResourceBundleMessageResolver(),
 
                         // EL式の処理を切り替える
                         new MessageInterpolator(new ExpressionLanguageJEXLImpl())))
+                .buildValidatorFactory();
+        Validator validator = validatorFactory.usingContext()
                 .getValidator();
 
         // BeanValidationのValidatorを渡す

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidatorTest.java
@@ -1,0 +1,528 @@
+package com.gh.mygreen.xlsmapper.validation.beanvalidation;
+
+import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.awt.Point;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.gh.mygreen.xlsmapper.XlsMapper;
+import com.gh.mygreen.xlsmapper.annotation.LabelledCellType;
+import com.gh.mygreen.xlsmapper.annotation.RecordTerminal;
+import com.gh.mygreen.xlsmapper.annotation.XlsColumn;
+import com.gh.mygreen.xlsmapper.annotation.XlsDateTimeConverter;
+import com.gh.mygreen.xlsmapper.annotation.XlsHorizontalRecords;
+import com.gh.mygreen.xlsmapper.annotation.XlsIgnorable;
+import com.gh.mygreen.xlsmapper.annotation.XlsLabelledCell;
+import com.gh.mygreen.xlsmapper.annotation.XlsSheet;
+import com.gh.mygreen.xlsmapper.expression.ExpressionLanguageJEXLImpl;
+import com.gh.mygreen.xlsmapper.localization.EncodingControl;
+import com.gh.mygreen.xlsmapper.localization.MessageInterpolator;
+import com.gh.mygreen.xlsmapper.localization.MessageResolver;
+import com.gh.mygreen.xlsmapper.localization.ResourceBundleMessageResolver;
+import com.gh.mygreen.xlsmapper.util.IsEmptyBuilder;
+import com.gh.mygreen.xlsmapper.validation.FieldError;
+import com.gh.mygreen.xlsmapper.validation.ObjectError;
+import com.gh.mygreen.xlsmapper.validation.SheetBindingErrors;
+import com.gh.mygreen.xlsmapper.validation.SheetErrorFormatter;
+
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * {@link JakartaSheetBeanValidator}のテスタ
+ * 
+ * @since 2.3
+ * @author T.TSUCHIE
+ *
+ */
+@Ignore("Jakarata Bean Validation 3.0 + Java11のときのみ")
+public class JakartaSheetBeanValidatorTest {
+    
+    private SheetErrorFormatter errorFormatter;
+    
+    @Before
+    public void setUp() throws Exception {
+        this.errorFormatter = new SheetErrorFormatter();
+    }
+    
+    private Validator getBeanValidator() {
+        
+        ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
+                .messageInterpolator(new JakartaMessageInterpolatorAdapter(
+                        new ResourceBundleMessageResolver(), new MessageInterpolator()))
+                .buildValidatorFactory();
+        
+        return validatorFactory.usingContext()
+                .getValidator();
+    }
+    
+    /**
+     * 単純なBeanのテスト - エラーなし
+     */
+    @Test
+    public void test_simple_success() throws Exception {
+        
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<SimpleBeanSheet> errors;
+        SimpleBeanSheet sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            
+            errors = mapper.loadDetail(in, SimpleBeanSheet.class);
+            sheet = errors.getTarget();
+            
+        }
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(getBeanValidator());
+        
+        // 値の補正
+        sheet.updateTime = getDateByDay(new Date(), 1);
+        
+        sheetValidator.validate(sheet, errors);
+        
+        assertThat(errors.getAllErrors(), hasSize(0));
+        
+    }
+    
+    /**
+     * 単純なBeanのテスト - エラーあり
+     */
+    @Test
+    public void test_simple_error() throws Exception {
+        
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<SimpleBeanSheet> errors;
+        SimpleBeanSheet sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            errors = mapper.loadDetail(in, SimpleBeanSheet.class);
+            sheet = errors.getTarget();
+            
+        }
+        
+        // データの書き換え
+        sheet.updateTime = getDateByDay(new Date(), 1); // 正しい値に補正
+        sheet.description = "あいうえおかきくけこさ";
+        sheet.age = -1;
+        sheet.email = "test";
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(getBeanValidator());
+        sheetValidator.validate(sheet, errors);
+        
+        printErrors(errors);
+        
+        
+        {
+            String fieldName = "description";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Length"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.description));
+            assertThat(fieldError.getVariables(), hasEntry("min", (Object)0));
+            assertThat(fieldError.getVariables(), hasEntry("max", (Object)10));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:説明 - セル(C7)の文字長'11'は、0～10の間で設定してください。"));
+        }
+        
+        {
+            String fieldName = "age";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Range"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.age));
+            assertThat(fieldError.getVariables(), hasEntry("min", (Object)0L));
+            assertThat(fieldError.getVariables(), hasEntry("max", (Object)100L));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:年齢 - セル(B9)の値'-1'は、0から100の間の値を設定してください。"));
+            
+        }
+        
+        {
+            String fieldName = "email";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Email"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.email));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:e-mail(必須) - セル(B10)の値'test'は、E-mail形式で設定してください。"));
+            
+        }
+        
+        
+    }
+    
+    /**
+     * リストなBeanのテスト - エラーなし
+     */
+    @Test
+    public void test_list_success() throws Exception {
+        
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<ListBeanSheet> errors;
+        ListBeanSheet sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            errors = mapper.loadDetail(in, ListBeanSheet.class);
+            sheet = errors.getTarget();
+            
+        }
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(getBeanValidator());
+        sheetValidator.validate(sheet, errors);
+        
+        printErrors(errors);
+        
+        assertThat(errors.getAllErrors(), hasSize(0));
+        
+    }
+    
+    /**
+     * リストなBeanのテスト - エラーあり
+     */
+    @Test
+    public void test_list_error() throws Exception {
+        
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<ListBeanSheet> errors;
+        ListBeanSheet sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            errors = mapper.loadDetail(in, ListBeanSheet.class);
+            sheet = errors.getTarget();
+        }
+        
+        // データの書き換え
+        sheet.className = null;
+        sheet.list.get(1).email = "test";
+        sheet.list.get(2).birthday = getDateByDay(new Date(), 1);
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(getBeanValidator());
+        sheetValidator.validate(sheet, errors);
+        
+        printErrors(errors);
+        
+        {
+            String fieldName = "className";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("NotBlank"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.className));
+        
+        }
+        try {
+            errors.pushNestedPath("list", 1);
+            PersonRecord record = sheet.list.get(1);
+            String fieldName = "email";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(record.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(record.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Email"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)record.email));
+        } finally {
+            errors.popNestedPath();
+        }
+        
+        try {
+            errors.pushNestedPath("list", 2);
+            PersonRecord record = sheet.list.get(2);
+            String fieldName = "birthday";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(record.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(record.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Past"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)record.birthday));
+            
+        } finally {
+            errors.popNestedPath();
+        }
+    }
+    
+    /**
+     * メッセージ処理系を独自のものにする。
+     * ・式言語処理を独自のものにする。
+     */
+    @Test
+    public void test_interpolator_el() throws Exception {
+        
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<SimpleBeanSheet> errors;
+        SimpleBeanSheet sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            errors = mapper.loadDetail(in, SimpleBeanSheet.class);
+            sheet = errors.getTarget();
+            
+        }
+        
+        // データの書き換え
+        sheet.updateTime = toTimestamp("2017-11-01 00:00:00.000");
+        sheet.description = "あいうえおかきくけこさ";
+        sheet.age = -1;
+        sheet.email = "test";
+        
+        // BeanValidatorの式言語の実装を独自のものにする。
+        MessageResolver messageResolver = new ResourceBundleMessageResolver(
+                ResourceBundle.getBundle("com.gh.mygreen.xlsmapper.validation.beanvalidation.OtherElMessages", new EncodingControl("UTF-8")));
+        
+        errorFormatter.setMessageResolver(messageResolver);
+        
+        ValidatorFactory validatorFactory = Validation.byDefaultProvider().configure()
+                .messageInterpolator(
+                        new JakartaMessageInterpolatorAdapter(messageResolver,
+                        new MessageInterpolator(new ExpressionLanguageJEXLImpl())))
+                .buildValidatorFactory();
+        Validator beanValidator = validatorFactory.usingContext()
+                .getValidator();
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(beanValidator);
+        sheetValidator.validate(sheet, errors);
+        
+        printErrors(errors);
+        
+        {
+            String fieldName = "updateTime";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Future"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.updateTime));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:更新日時 - セル(B4)は未来の日付を入力してください。現在の日付「2017/11/01」は過去日です。"));
+        }
+        
+        {
+            String fieldName = "description";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Length"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.description));
+            assertThat(fieldError.getVariables(), hasEntry("min", (Object)0));
+            assertThat(fieldError.getVariables(), hasEntry("max", (Object)10));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:説明 - セル(C7)は0～10文字以内で値を入力してください。"));
+            
+        }
+        
+        {
+            String fieldName = "age";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Range"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.age));
+            assertThat(fieldError.getVariables(), hasEntry("min", (Object)0L));
+            assertThat(fieldError.getVariables(), hasEntry("max", (Object)100L));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:年齢 - セル(B9)は0から100の間の値を入力してください。"));
+        }
+        
+        {
+            String fieldName = "email";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), hasItemInArray("Email"));
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.email));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("[単純なBean]:e-mail(必須) - セル(B10)はメールアドレスの形式(例:hoge@sample.co.jp)で値を入力してください。"));
+
+        }
+        
+        
+    }
+    
+    /**
+     * アノテーションのメッセージ属性の変更 - エラーあり
+     */
+    @Test
+    public void test_change_attribute_message() throws Exception {
+        
+
+        XlsMapper mapper = new XlsMapper();
+        mapper.getConfiguration().setContinueTypeBindFailure(true);
+        
+        // シートの読み込み
+        SheetBindingErrors<ChangeAttributeMessage> errors;
+        ChangeAttributeMessage sheet;
+        try(InputStream in = new FileInputStream("src/test/data/validator_bean.xlsx")) {
+            errors = mapper.loadDetail(in, ChangeAttributeMessage.class);
+            sheet = errors.getTarget();
+            
+        }
+        
+        // データの書き換え
+        sheet.code = "あいうえお"; // 不正な値に変更
+        
+        // 入力値検証
+        JakartaSheetBeanValidator sheetValidator = new JakartaSheetBeanValidator(getBeanValidator());
+        sheetValidator.validate(sheet, errors);
+        
+        printErrors(errors);
+        
+        
+        {
+            String fieldName = "code";
+            FieldError fieldError = errors.getFirstFieldError(fieldName).get();
+            assertThat(fieldError.getAddress().toPoint(), is(sheet.positions.get(fieldName)));
+            assertThat(fieldError.getLabel(), is(sheet.labels.get(fieldName)));
+            assertThat(fieldError.getCodes(), emptyArray());    // ユーザーメッセージの場合はエラーコードは空。
+            assertThat(fieldError.getVariables(), hasEntry("validatedValue", (Object)sheet.code));
+            assertThat(fieldError.getVariables(), hasEntry("regexp", "[\\p{Alnum}]+"));
+            
+            String message = errorFormatter.format(fieldError);
+            assertThat(message, is("半角英数字で設定してください。"));
+        }
+        
+    }
+    
+    private void printErrors(SheetBindingErrors<?> errors) {
+        
+        for(ObjectError error : errors.getAllErrors()) {
+            String message = errorFormatter.format(error);
+            System.out.println(message);
+        }
+        
+    }
+    
+    @XlsSheet(name="単純なBean")
+    private static class SimpleBeanSheet {
+        
+        private Map<String, Point> positions;
+        
+        private Map<String, String> labels;
+        
+        @Length(max=10)
+        @XlsLabelledCell(label="説明", type=LabelledCellType.Bottom)
+        private String description;
+        
+        @Range(min=0, max=100)
+        @XlsLabelledCell(label="年齢", type=LabelledCellType.Right)
+        private Integer age;
+        
+        @NotBlank
+        @Email
+        @XlsLabelledCell(label="e-mail(必須)", type=LabelledCellType.Right)
+        private String email;
+        
+        @DecimalMin(value="0.0", inclusive=true)
+        @XlsLabelledCell(label="得点（平均）", type=LabelledCellType.Right)
+        private Double average;
+        
+        @NotNull
+        @Future
+        @XlsDateTimeConverter(lenient=true, javaPattern="yyyy年M月d日")
+        @XlsLabelledCell(label="更新日時", type=LabelledCellType.Right)
+        private Date updateTime;
+        
+    }
+    
+    @XlsSheet(name="リストのBean")
+    private static class ListBeanSheet {
+        
+        private Map<String, Point> positions;
+        
+        private Map<String, String> labels;
+        
+        @NotBlank
+        @XlsLabelledCell(label="クラス名", type=LabelledCellType.Right)
+        private String className;
+        
+        @Valid
+        @XlsHorizontalRecords(tableLabel="名簿一覧", terminal=RecordTerminal.Border)
+        private List<PersonRecord> list;
+        
+    }
+    
+    private static class PersonRecord {
+        
+        private Map<String, Point> positions;
+        
+        private Map<String, String> labels;
+        
+        @XlsColumn(columnName="No.")
+        private int no;
+        
+        @Length(max=10)
+        @XlsColumn(columnName="氏名")
+        private String name;
+        
+        @NotBlank
+        @Email
+        @XlsColumn(columnName="メールアドレス")
+        private String email;
+        
+        @NotNull
+        @Past
+        @XlsDateTimeConverter(lenient=true, javaPattern="yyyy年M月d日")
+        @XlsColumn(columnName="生年月日")
+        private Date birthday;
+        
+        @XlsIgnorable
+        public boolean isEmpty() {
+            return IsEmptyBuilder.reflectionIsEmpty(this, "positions", "labels", "no");
+        }
+        
+    }
+    
+    @XlsSheet(name="メッセージ属性を変更")
+    private static class ChangeAttributeMessage {
+        
+        private Map<String, Point> positions;
+        
+        private Map<String, String> labels;
+        
+        @Pattern(regexp="[\\p{Alnum}]+", message="半角英数字で設定してください。")
+        @XlsLabelledCell(label="コード", type=LabelledCellType.Right)
+        private String code;
+        
+    }
+}

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/OtherElMessages_ja.properties
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/OtherElMessages_ja.properties
@@ -2,12 +2,12 @@
 
 ## JSR-303のエラーメッセージ
 javax.validation.constraints.Future.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は未来の日付を入力してください。現在の日付「${formatter.format("%1$tY/%1$tm/%1$td", validatedValue)}」は過去日です。
+javax.validation.constraints.Email.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})はメールアドレスの形式(例:hoge@sample.co.jp)で値を入力してください。
+javax.validation.constraints.NotBlank.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は必須です。
 
 ## Hibernate Validatorのエラーメッセージ
-org.hibernate.validator.constraints.Email.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})はメールアドレスの形式(例:hoge@sample.co.jp)で値を入力してください。
 org.hibernate.validator.constraints.Length.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は{min}～{max}文字以内で値を入力してください。
-org.hibernate.validator.constraints.NotBlank.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は必須です。
 org.hibernate.validator.constraints.Range.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は${formatter.format('%d', min)}から${formatter.format('%d', max)}の間の値を入力してください。
-
-
+org.hibernate.validator.constraints.Email.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})はメールアドレスの形式(例:hoge@sample.co.jp)で値を入力してください。
+org.hibernate.validator.constraints.NotBlank.message=[{sheetName}]:${empty label ? '' : label} - セル({cellAddress})は必須です。
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidatorTest.java
@@ -17,14 +17,14 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Email;
 import javax.validation.constraints.Future;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
 import javax.validation.constraints.Pattern;
 
-import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.Length;
-import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.Range;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Jakarta Bean Validation 3.0の対応

- 実装である Hibernate 8.0 はJava11以上が必要になるため、デフォルトは今まで通り Bean Validation 2.0(Hibernate 6.0)のまま。
- Bean Validation 3.0用のクラスとして `JakarataSheatBeanValidator` / `JakartaMessageInterpolatorAdapter` を追加。
- Bean Validation 3.0用のメッセージを `SheetValidationMessages.properties` に追加。
- 既存の実装である `SheetBeanValidator` において、`org.hibernate.validator.internal.engine.path.PathImpl` からリフレクションを使用して、エラー発生個所のパスを取得するよう変更。
  -  Hibernate8 を読み込んだ場合、インタフェースが `javax.validation.Path` -> `jakarta.validation.Path` に変わったことによりコンパイルエラーが発生することになったため。
  - ビルド時は BeanValidation2.0 と 3.0で共存できるようにした。