### PR TITLE
GitHub Actions のタイムゾーンの指定

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,4 +37,6 @@ jobs:
       with:
         maven-version: 3.9.6
     - name: Build with Maven
+      env:
+        TZ: 'Asia/Tokyo'
       run: mvn -B clean verify -Dgpg.skip=true


### PR DESCRIPTION
タイムゾーン指定するときのテストが失敗するため、環境変数 `TZ=Asia/Tokyo` を指定。