### PR TITLE
テストクラスのdeperecatedのimportの見直し。

### DIFF
--- a/src/test/java/com/gh/mygreen/xlsmapper/SampleTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/SampleTest.java
@@ -2,8 +2,8 @@ package com.gh.mygreen.xlsmapper;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/BooleanCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/BooleanCellConverterTest.java
@@ -1,8 +1,9 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.File;

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/CollectionCellConveterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/CollectionCellConveterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/DateTimeCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/DateTimeCellConverterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/EnumCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/EnumCellConverterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/LinkCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/LinkCellConverterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/NumberCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/NumberCellConverterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/TextCellConverterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/cellconverter/TextCellConverterTest.java
@@ -1,6 +1,7 @@
 package com.gh.mygreen.xlsmapper.cellconverter;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/ArrayLabelSetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/ArrayLabelSetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/FieldAccessorFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/FieldAccessorFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.lang.reflect.Field;
@@ -25,8 +24,6 @@ import com.gh.mygreen.xlsmapper.annotation.XlsHorizontalRecords;
 import com.gh.mygreen.xlsmapper.annotation.XlsLabelledCell;
 import com.gh.mygreen.xlsmapper.annotation.XlsMapColumns;
 import com.gh.mygreen.xlsmapper.annotation.XlsOrder;
-import com.gh.mygreen.xlsmapper.fieldaccessor.FieldAccessor;
-import com.gh.mygreen.xlsmapper.fieldaccessor.FieldAccessorFactory;
 import com.gh.mygreen.xlsmapper.xml.AnnotationReader;
 
 /**

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/LabelGetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/LabelGetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashMap;
@@ -10,8 +9,6 @@ import java.util.Optional;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.util.CellReference;
 import org.junit.Before;
-
-
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/LabelSetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/LabelSetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Map;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/MapLabelSetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/MapLabelSetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashMap;
@@ -10,7 +9,6 @@ import java.util.Optional;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.util.CellReference;
 import org.junit.Before;
-
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/MapPositionSetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/MapPositionSetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.awt.Point;
@@ -12,7 +11,6 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellReference;
 import org.junit.Before;
-
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/PositionGetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/PositionGetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.awt.Point;
@@ -11,8 +10,6 @@ import java.util.Optional;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.util.CellReference;
 import org.junit.Before;
-
-
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/PositionSetterFactoryTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldaccessor/PositionSetterFactoryTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.fieldaccessor;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.awt.Point;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoCellTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoCellTest.java
@@ -2,8 +2,8 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 import java.awt.Point;
 import java.io.File;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoCommentOptionTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoCommentOptionTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoFormulaTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoFormulaTest.java
@@ -2,6 +2,7 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoHorizontalRecordsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoHorizontalRecordsTest.java
@@ -3,9 +3,9 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.awt.Point;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoIterateTablesTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoIterateTablesTest.java
@@ -2,8 +2,8 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.awt.Point;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLabelledArrayCellsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLabelledArrayCellsTest.java
@@ -4,8 +4,8 @@ import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLabelledCellTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLabelledCellTest.java
@@ -2,8 +2,8 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.awt.Point;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLifeCycleTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoLifeCycleTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.File;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoSheetNameTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoSheetNameTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.fieldprocessor;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoSheetTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoSheetTest.java
@@ -1,9 +1,10 @@
 package com.gh.mygreen.xlsmapper.fieldprocessor;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoVerticalRecordsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/AnnoVerticalRecordsTest.java
@@ -3,9 +3,9 @@ package com.gh.mygreen.xlsmapper.fieldprocessor;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.awt.Point;

--- a/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/RecordsProcessorUtilTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/fieldprocessor/RecordsProcessorUtilTest.java
@@ -15,7 +15,6 @@ import com.gh.mygreen.xlsmapper.annotation.XlsNestedRecords;
 import com.gh.mygreen.xlsmapper.annotation.XlsSheet;
 import com.gh.mygreen.xlsmapper.fieldaccessor.FieldAccessor;
 import com.gh.mygreen.xlsmapper.fieldaccessor.FieldAccessorFactory;
-import com.gh.mygreen.xlsmapper.fieldprocessor.RecordsProcessorUtil;
 import com.gh.mygreen.xlsmapper.xml.AnnotationReader;
 
 /**

--- a/src/test/java/com/gh/mygreen/xlsmapper/localization/MessageInterpolatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/localization/MessageInterpolatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.localization;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.Date;

--- a/src/test/java/com/gh/mygreen/xlsmapper/localization/ResourceBundleMessageResolverTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/localization/ResourceBundleMessageResolverTest.java
@@ -1,11 +1,9 @@
 package com.gh.mygreen.xlsmapper.localization;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
 import java.util.ResourceBundle;
-
-import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/gh/mygreen/xlsmapper/sample/dbdefinition/EntityDefinitionTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/sample/dbdefinition/EntityDefinitionTest.java
@@ -1,13 +1,11 @@
 package com.gh.mygreen.xlsmapper.sample.dbdefinition;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -15,8 +13,6 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/spring/SpringTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/spring/SpringTest.java
@@ -1,6 +1,6 @@
 package com.gh.mygreen.xlsmapper.spring;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 import java.awt.Point;
@@ -18,9 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.gh.mygreen.xlsmapper.Configuration;
 import com.gh.mygreen.xlsmapper.SpringBeanFactory;
 import com.gh.mygreen.xlsmapper.XlsMapper;
-import com.gh.mygreen.xlsmapper.Configuration;
 import com.gh.mygreen.xlsmapper.annotation.XlsColumn;
 import com.gh.mygreen.xlsmapper.annotation.XlsHorizontalRecords;
 import com.gh.mygreen.xlsmapper.annotation.XlsPostLoad;

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/CellFinderTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/CellFinderTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.util;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.File;
@@ -12,9 +11,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.Before;
-
-
-
 import org.junit.Test;
 
 import com.gh.mygreen.xlsmapper.Configuration;

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/CellPositionTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/CellPositionTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.util;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Test;

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/IsEmptyBuilderTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/IsEmptyBuilderTest.java
@@ -1,7 +1,7 @@
 package com.gh.mygreen.xlsmapper.util;
 
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,10 +12,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.gh.mygreen.xlsmapper.util.IsEmptyBuilder;
-import com.gh.mygreen.xlsmapper.util.IsEmptyComparator;
-import com.gh.mygreen.xlsmapper.util.IsEmptyConfig;
 
 /**
  * {@link IsEmptyBuilder}のテスタ。

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/POIUtilsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/POIUtilsTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.util;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyPathTokenizerTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyPathTokenizerTest.java
@@ -1,7 +1,7 @@
 package com.gh.mygreen.xlsmapper.util;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.util.List;
 
@@ -10,7 +10,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.gh.mygreen.xlsmapper.util.PropertyPathTokenizer;
 import com.gh.mygreen.xlsmapper.util.PropertyPath.Token;
 
 /**

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyTypeNavigatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyTypeNavigatorTest.java
@@ -1,6 +1,5 @@
 package com.gh.mygreen.xlsmapper.util;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyValueNavigatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/PropertyValueNavigatorTest.java
@@ -1,5 +1,6 @@
 package com.gh.mygreen.xlsmapper.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -11,9 +12,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import com.gh.mygreen.xlsmapper.util.PropertyAccessException;
-import com.gh.mygreen.xlsmapper.util.PropertyValueNavigator;
 
 /**
  * {@link PropertyValueNavigator}のテスタ

--- a/src/test/java/com/gh/mygreen/xlsmapper/util/UtilsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/util/UtilsTest.java
@@ -1,8 +1,10 @@
 package com.gh.mygreen.xlsmapper.util;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/ObjectValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/ObjectValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/SheetBindingErrorsTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/SheetBindingErrorsTest.java
@@ -1,19 +1,12 @@
 package com.gh.mygreen.xlsmapper.validation;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
 import static org.assertj.core.api.Assertions.*;
-import static com.gh.mygreen.xlsmapper.TestUtils.*;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.gh.mygreen.xlsmapper.util.CellPosition;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/JakartaSheetBeanValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.beanvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/beanvalidation/SheetBeanValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.beanvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.FileInputStream;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/ArrayValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/ArrayValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.text.DecimalFormat;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/DateValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/DateValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.sql.Time;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/FieldValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/FieldValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.util.Date;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/NumberValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/NumberValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.text.DecimalFormat;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/StringValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/StringValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.util.LinkedHashMap;

--- a/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/TemporalValidatorTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/validation/fieldvalidation/TemporalValidatorTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.validation.fieldvalidation;
 
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.time.LocalDate;

--- a/src/test/java/com/gh/mygreen/xlsmapper/xml/AnnotationReaderTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/xml/AnnotationReaderTest.java
@@ -1,8 +1,8 @@
 package com.gh.mygreen.xlsmapper.xml;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static com.gh.mygreen.xlsmapper.TestUtils.*;
+import static org.junit.Assert.*;
 
 import java.awt.Point;
 import java.io.File;
@@ -21,15 +21,15 @@ import com.gh.mygreen.xlsmapper.annotation.RecordTerminal;
 import com.gh.mygreen.xlsmapper.annotation.XlsCellOption;
 import com.gh.mygreen.xlsmapper.annotation.XlsConverter;
 import com.gh.mygreen.xlsmapper.annotation.XlsDefaultValue;
-import com.gh.mygreen.xlsmapper.annotation.XlsOrder;
 import com.gh.mygreen.xlsmapper.annotation.XlsHorizontalRecords;
 import com.gh.mygreen.xlsmapper.annotation.XlsLabelledCell;
+import com.gh.mygreen.xlsmapper.annotation.XlsOrder;
 import com.gh.mygreen.xlsmapper.annotation.XlsSheet;
 import com.gh.mygreen.xlsmapper.annotation.XlsSheetName;
 import com.gh.mygreen.xlsmapper.annotation.XlsTrim;
 import com.gh.mygreen.xlsmapper.xml.bind.AnnotationInfo;
-import com.gh.mygreen.xlsmapper.xml.bind.ClassInfo;
 import com.gh.mygreen.xlsmapper.xml.bind.AnnotationMappingInfo;
+import com.gh.mygreen.xlsmapper.xml.bind.ClassInfo;
 
 /**
  * {@link XmlIO}、{@link AnnotationReader}のテスタ

--- a/src/test/java/com/gh/mygreen/xlsmapper/xml/DynamicAnnotationBuilderTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/xml/DynamicAnnotationBuilderTest.java
@@ -1,8 +1,7 @@
 package com.gh.mygreen.xlsmapper.xml;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static com.gh.mygreen.xlsmapper.TestUtils.*;
 
 import java.lang.annotation.Annotation;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/xml/OgnlValueFormatterTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/xml/OgnlValueFormatterTest.java
@@ -1,5 +1,6 @@
 package com.gh.mygreen.xlsmapper.xml;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/gh/mygreen/xlsmapper/xml/XmlBuilderTest.java
+++ b/src/test/java/com/gh/mygreen/xlsmapper/xml/XmlBuilderTest.java
@@ -1,9 +1,9 @@
 package com.gh.mygreen.xlsmapper.xml;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
 import static com.gh.mygreen.xlsmapper.TestUtils.*;
 import static com.gh.mygreen.xlsmapper.xml.XmlBuilder.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 import java.awt.Point;
 import java.io.File;
@@ -22,17 +22,17 @@ import com.gh.mygreen.xlsmapper.annotation.XlsCell;
 import com.gh.mygreen.xlsmapper.annotation.XlsCellOption;
 import com.gh.mygreen.xlsmapper.annotation.XlsConverter;
 import com.gh.mygreen.xlsmapper.annotation.XlsDefaultValue;
-import com.gh.mygreen.xlsmapper.annotation.XlsOrder;
 import com.gh.mygreen.xlsmapper.annotation.XlsHorizontalRecords;
 import com.gh.mygreen.xlsmapper.annotation.XlsLabelledCell;
+import com.gh.mygreen.xlsmapper.annotation.XlsOrder;
 import com.gh.mygreen.xlsmapper.annotation.XlsSheet;
 import com.gh.mygreen.xlsmapper.annotation.XlsSheetName;
 import com.gh.mygreen.xlsmapper.annotation.XlsTrim;
 import com.gh.mygreen.xlsmapper.xml.bind.AnnotationInfo;
+import com.gh.mygreen.xlsmapper.xml.bind.AnnotationMappingInfo;
 import com.gh.mygreen.xlsmapper.xml.bind.ClassInfo;
 import com.gh.mygreen.xlsmapper.xml.bind.FieldInfo;
 import com.gh.mygreen.xlsmapper.xml.bind.MethodInfo;
-import com.gh.mygreen.xlsmapper.xml.bind.AnnotationMappingInfo;
 
 /**
  * {@link XmlBuilder}のテスタ

--- a/src/test/java/test/external/ExternalTest.java
+++ b/src/test/java/test/external/ExternalTest.java
@@ -1,5 +1,6 @@
 package test.external;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
JUnitのmatcherのImportにおいて、deprecatedのメソッドの修正。
- `org.junit.Asser.assertThat` -> `org.hamcrest.MatcherAssert.assertThat`